### PR TITLE
Твики подключения

### DIFF
--- a/insales/connection.py
+++ b/insales/connection.py
@@ -72,8 +72,15 @@ class Connection(object):
         if 200 <= resp.status < 300:
             return body
         else:
-            raise ApiError("%s request to %s returned: %s\n%s" %
-                           (method, path, resp.status, body), resp.status)
+            raise ApiError(
+                "{} request to {} returned: {}\n{}".format(
+                    method,
+                    path,
+                    resp.status,
+                    body.decode('utf-8') if type(body) == bytes else body
+                ),
+                resp.status
+            )
 
     def format_path(self, endpoint, qargs):
         for key, val in qargs.items():

--- a/insales/connection.py
+++ b/insales/connection.py
@@ -10,11 +10,11 @@ try:
     # Python 3
     from urllib import parse as urlparse
     from urllib.parse import urlencode
-    from http.client import HTTPConnection, HTTPException
+    from http.client import HTTPConnection, HTTPSConnection, HTTPException
 except ImportError:
     # Python 2
     import urlparse
-    from httplib import HTTPConnection, HTTPException
+    from httplib import HTTPConnection, HTTPSConnection, HTTPException
     from urllib import urlencode
 
 
@@ -26,11 +26,13 @@ class ApiError(Exception):
 
 class Connection(object):
     def __init__(self, account, api_key, password,
+                 secure=False,
                  retry_on_503=False, retry_on_socket_error=False,
                  retry_timeout=1, response_timeout=10):
         self.account = account
         self.api_key = api_key
         self.password = password
+        self.secure = secure
         self.retry_on_503 = retry_on_503
         self.retry_on_socket_error = retry_on_socket_error
         self.retry_timeout = retry_timeout
@@ -47,8 +49,11 @@ class Connection(object):
         done = False
         while not done:
             try:
-                conn = HTTPConnection('%s.myinsales.ru:80' % self.account,
-                                      timeout=self.response_timeout)
+                host = '%s.myinsales.ru' % self.account
+                if self.secure:
+                    conn = HTTPSConnection(host, timeout=self.response_timeout)
+                else:
+                    conn = HTTPConnection(host, timeout=self.response_timeout)
                 conn.request(method, path, headers=headers, body=data)
                 resp = conn.getresponse()
                 body = resp.read()


### PR DESCRIPTION
Теперь поддерживается подключение по HTTPS. По-умолчанию остаётся HTTP.

Ошибки, возвращаемые InSales, теперь декодируются из байт в текст и их может прочитать человек.

Если после исчерпания лимита на количество запросов к API мы получаем заголовок `Retry-After` с количеством секунд, то мы повторяем не через `retry_timeout` (1s by default), а ждём столько, сколько нам рекомендовали. Однако, ограничиваем время ожидания 60 секундами, чтобы не быть уязвимыми к какой-нибудь ошибке с другой стороны, когда нас попросили подождать миллион лет. Благодаря этому значительно меньше тратятся ресурсы с нашей стороны и со стороны InSales, особенно при многопоточной работе, когда у каждого потока свой `retry_after`. Плюс запросы, возвращающие 503, тоже увеличивают счетчик запросов.

Далее немного спорная опция. InSales даёт делать 500 запросов в 5 минут. Причём этот лимит не размазан как-то во времени, а прям строго через пять минут после первого запроса в серии обнуляется счетчик сделанных запросов и у тебя опять есть 500 запросов. В некоторых сценариях получается, что скрипт употребляет весь лимит за несколько секунд, а потом почти пять минут "висит". CircleCI, например, несколько раз прибивал job из-за отсутствия вывода :) Плюс, если трудится несколько скриптов одновременно, то один может просто напрочь заблокировать остальных.

InSales передаёт в заголовке `API-Usage-Limit` максимальное количество запросов в этот промежуток времени и сколько их уже было. Т.е. фактически известен баланс после каждого запроса. 

Добавляется возможность включить флаг `throttle` (выключен по умолчанию) и даже передать функцию замедления `throttle_fn`. Текущий баланс передаётся в `throttle_fn`, она возвращает задержку в секундах. Можно нафантазировать себе линейный рейт запросов 5*60/500, например. По-умолчанию подобрана такая функция, что сумма числового ряда от 0 до 500 даёт как раз 300 секунд ожидания. При этом большую часть пути ожидания нет (потому что ожидание меньше round trip) и только в самом конце ожидание между запросами радикально прогрессирует до максимальных 10 секунд. При работе в один поток баланс никогда не выгребается, потому что после последнего запроса добавляется новые 500 запросов и всё опять ускоряется.

Побочное явление: Использование `datetime` для `Connection.retry_after` делает удобным недобросовестное использование, когда делается пул подключений с разными credentials и запрос делается через то, где ждать меньше.