### PR TITLE
Паджинация списка статей в блогах

### DIFF
--- a/insales/api.py
+++ b/insales/api.py
@@ -471,8 +471,10 @@ class InSalesApi(object):
     #========================================================================
     # Статьи (в блоге)
     #========================================================================
-    def get_articles(self, blog_id):
-        return self._get('/admin/blogs/%s/articles.xml' % blog_id)
+    def get_articles(self, blog_id, per_page = 10, page = 1):
+        "Get orders: https://api.insales.ru/?doc_format=XML#article-get-articles-list-xml"
+        qargs = {"per_page": per_page, "page": page}
+        return self._get('/admin/blogs/%s/articles.xml' % blog_id, qargs) or []
 
     def get_article(self, blog_id, article_id):
         return self._get('/admin/blogs/%s/articles/%s.xml' % (blog_id, article_id))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", 'rb') as f:
 
 setup(
     name='pyinsales',
-    version='1.7.0',
+    version='1.8.0',
     description='InSales e-commerce platform API bindings',
     long_description=readme_content,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Императивно выявлено, что ендпоинт умеет принимать параметры `per_page` и `page`. Но не умеет традиционные `updated_since` и `from_id`. Но этого достаточно.